### PR TITLE
Fix zombie scripts when USB stick is unplugged

### DIFF
--- a/runusb
+++ b/runusb
@@ -275,6 +275,7 @@ def main(args=sys.argv[1:]):
         print(get_machinename(path))
         command = ('machinectl', 'terminate', get_machinename(path))
         subprocess.call(command)
+        process.wait(timeout=5)
         process.kill()
 
     def is_autorun_mountpoint(path):

--- a/runusb
+++ b/runusb
@@ -29,6 +29,14 @@ def argument_parser():
     )
 
     parser.add_argument(
+        '--debug',
+        help="enable very verbose output",
+        action='store_const',
+        const=logging.DEBUG,
+        dest='log_level',
+    )
+
+    parser.add_argument(
         '--runfile',
         help="name of the autorun file to detect",
         action='store',

--- a/runusb
+++ b/runusb
@@ -274,7 +274,7 @@ def main(args=sys.argv[1:]):
         # to die horribly.
         print(get_machinename(path))
         command = ('machinectl', 'terminate', get_machinename(path))
-        result = subprocess.check_call(command)
+        subprocess.call(command)
         process.kill()
 
     def is_autorun_mountpoint(path):

--- a/runusb
+++ b/runusb
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os.path
+import re
 import sys
 import select
 import logging
@@ -216,6 +217,9 @@ def main(args=sys.argv[1:]):
 
     logging.basicConfig(level=options.log_level)
 
+    def get_machinename(path):
+        return re.sub(r'[^\w]', r'_', path).strip('_')
+
     # Actual process drivers
     def open_process(path):
         command = ['systemd-nspawn']
@@ -240,6 +244,10 @@ def main(args=sys.argv[1:]):
         # Bind-mount the actual path
         command.extend(('--bind', path))
 
+        # Attach a machine ID, use the path as the ID
+        print(get_machinename(path))
+        command.extend(('--machine', get_machinename(path)))
+
         # Run the autorun file with bash -c
         command.extend(('/bin/bash', '-c'))
 
@@ -256,6 +264,11 @@ def main(args=sys.argv[1:]):
     def close_process(path, process):
         # With the mountpoint now missing the only sensible thing to do is
         # to die horribly.
+        print(get_machinename(path))
+        command = ('machinectl', 'terminate', get_machinename(path))
+        result = subprocess.call(command)
+        if result:
+            raise RuntimeError("Non-zero return code from {}".format(command))
         process.kill()
 
     def is_autorun_mountpoint(path):

--- a/runusb
+++ b/runusb
@@ -266,9 +266,7 @@ def main(args=sys.argv[1:]):
         # to die horribly.
         print(get_machinename(path))
         command = ('machinectl', 'terminate', get_machinename(path))
-        result = subprocess.call(command)
-        if result:
-            raise RuntimeError("Non-zero return code from {}".format(command))
+        result = subprocess.check_call(command)
         process.kill()
 
     def is_autorun_mountpoint(path):


### PR DESCRIPTION
Split systemd-nspawn and bash calls to separate subprocess commands
This means the bash script is killed upon removal. 

Before, the 2 commands were executed as separate processes despite only having 1 process ID, thus when process.kill() was called, it would kill the one which had already exited, leaving a zombie process

fixes: #2 