### PR TITLE
Remove automatic printing of datetimes in the log file

### DIFF
--- a/runusb
+++ b/runusb
@@ -132,7 +132,7 @@ def open_run_robot_code_process(path):
 
     # cd to the mountpoint and run the autorun file
     command.append(
-        'cd "{mountpoint}" ; script -ec "python3 {autorun}" -f log.txt'.format(
+        'cd "{mountpoint}" ; script --quiet -ec "python3 {autorun}" -f log.txt'.format(
             mountpoint=path,
             autorun=ROBOT_FILE,
         ),


### PR DESCRIPTION
Due to the lack of either a network connection or a permanent power
source, the clock on the Pi is nearly always wrong. While we could
go to extortionate lengths to somehow keep it correct, this doesn't
really feel like an effective use of our time.

Currently `runusb` prints the current date and time at the beginning
and end of the log [1], but because the clock is completely wrong
this information is misleading [2]. I propose we disable this
behaviour.

Note that we do lose *some* potentially useful information by doing
this: the duration for which the program was executed. This should
be easy enough to add back in however, even if it's just wrapping
the subprocess with the `time` command.

[1] Specifically, it's the invokation of the `script` command that
prints it. Passing the `-q`/`--quiet` flag to `script` should disable
this behaviour.

[2] I've heard things like "the Pi's clearly not executing our
code because the logfile date is from months ago" at least a couple
of times, more from us developers than from the competitors.