### PR TITLE
Require `systemd-nspawn`

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Architecture: all
 Depends: ${misc:Depends},
          python3,
          robotd,
+         systemd-container,
 Description: Automagic running of USB sticks
  Runs .autorun files from mounted USB sticks - or other filesystems -
  automatically, and safely containerised.


### PR DESCRIPTION
Stretch no longer ships with `systemd-nspawn` by default, so we need to explicitly depend on it

Moved from https://github.com/sourcebots/pi-image/pull/8