### PR TITLE
Use tempdir for extraction

### DIFF
--- a/sb-update
+++ b/sb-update
@@ -2,13 +2,15 @@
 
 import argparse
 import os
+import pathlib
 import subprocess
-from glob import glob
+import tempfile
 import shutil
 import logging
 
+from typing import List
+
 UPDATE_FILENAME = 'update.tar.xz'
-UPDATE_DIR = '/updating'
 SB_DEBS = '/sb-debs'
 LOG_FILE = 'update.log'
 
@@ -45,7 +47,7 @@ def update_and_upgrade():
     subprocess.check_call(['apt', 'upgrade', '-y'], stdout=subprocess.DEVNULL)
 
 
-def validate_deb(deb_path):
+def validate_deb(deb_path: pathlib.Path) -> None:
     """
     Validate that the given path is indeed a debian package.
 
@@ -60,6 +62,49 @@ def validate_deb(deb_path):
         raise ValueError("file {} is not a deb file!".format(deb_path))
 
 
+def _extract_debs(
+    update_file: pathlib.Path,
+    working_dir: tempfile.TemporaryDirectory,
+) -> List[pathlib.Path]:
+
+    subprocess.check_call(
+        [
+            'tar',
+            '--extract',
+            '--xz',
+            '--file', update_file,
+        ],
+        cwd=working_dir,
+    )
+
+    return working_dir.glob("*.deb")
+
+
+def add_debs_to_local_repo_from(update_file: pathlib.Path) -> None:
+    """
+    Given the path to an xz-compressed tarball, copy any .deb files to the
+    ``SB_DEBS`` directory.
+    """
+
+    with tempfile.TemporaryDirectory(prefix='updates-') as updates_dir:
+        found_debs = _extract_debs(update_file, pathlib.Path(updates_dir))
+
+        if not found_debs:
+            raise FileNotFoundError(
+                "Failed to find deb files in {}, exiting".format(update_file),
+            )
+
+        logging.debug("Found {} potential packages".format(len(found_debs)))
+
+        # Check that all the debs are valid
+        for deb_path in found_debs:
+            validate_deb(deb_path)
+
+            logging.debug("Adding {} to internal repo".format(
+                os.path.basename(deb),
+            ))
+            shutil.copy(deb, SB_DEBS)
+
 
 def main():
     options = argument_parser().parse_args()
@@ -70,26 +115,17 @@ def main():
             logging.StreamHandler()
         ]
     )
-    update_file = os.path.join(options.path, UPDATE_FILENAME)
+    update_file = pathlib.Path(os.path.join(options.path, UPDATE_FILENAME))
 
     logging.info("Starting updates from {}".format(update_file))
-    os.mkdir(UPDATE_DIR)
-    subprocess.check_call(['tar', 'xJf', update_file, '-C', UPDATE_DIR])
-    os.remove(update_file)
-    deb_glob = glob("{}/*.deb".format(UPDATE_DIR))
-    if len(deb_glob) == 0:
-        raise FileNotFoundError("Can't find deb files in {}, exiting".format(UPDATE_DIR))
+    add_debs_to_local_repo_from(update_file)
 
-    logging.debug("Found {} potential packages".format(len(deb_glob)))
-    for deb in deb_glob:
-        logging.debug("Adding {} to internal repo".format(os.path.basename(deb)))
-        shutil.copy(deb, SB_DEBS)
+    update_file.unlink()
 
     rebuild_apt_repo()
     update_and_upgrade()
 
     logging.info("Upgrade complete, cleaning up.")
-    shutil.rmtree(UPDATE_DIR)
 
     logging.info("Rebooting.")
     subprocess.check_call(["reboot"])

--- a/sb-update
+++ b/sb-update
@@ -77,7 +77,7 @@ def _extract_debs(
         cwd=str(working_dir),
     )
 
-    return working_dir.glob("*.deb")
+    return list(working_dir.glob("*.deb"))
 
 
 def add_debs_to_local_repo_from(update_file: pathlib.Path) -> None:

--- a/sb-update
+++ b/sb-update
@@ -100,6 +100,11 @@ def add_debs_to_local_repo_from(update_file: pathlib.Path) -> None:
         for deb_path in found_debs:
             validate_deb(deb_path)
 
+        # Add all the debs to the repo directory.
+        # Note that we do this _separately_ after the checking, so that we can
+        # be somewhat confident that either all the debs that were in the
+        # update are all in the repo or none are.
+        for deb_path in found_debs:
             logging.debug("Adding {} to internal repo".format(
                 os.path.basename(deb),
             ))

--- a/sb-update
+++ b/sb-update
@@ -54,7 +54,7 @@ def validate_deb(deb_path: pathlib.Path) -> None:
     Raises ``ValueError`` if the package is not valid.
     """
     check_deb = subprocess.call(
-        ['dpkg', '--info', deb_path],
+        ['dpkg', '--info', str(deb_path)],
         stdout=subprocess.DEVNULL,
     )
 

--- a/sb-update
+++ b/sb-update
@@ -129,9 +129,7 @@ def main():
     rebuild_apt_repo()
     update_and_upgrade()
 
-    logging.info("Upgrade complete, cleaning up.")
-
-    logging.info("Rebooting.")
+    logging.info("Upgrade complete, rebooting.")
     subprocess.check_call(["reboot"])
 
 

--- a/sb-update
+++ b/sb-update
@@ -72,9 +72,9 @@ def _extract_debs(
             'tar',
             '--extract',
             '--xz',
-            '--file', update_file,
+            '--file', str(update_file),
         ],
-        cwd=working_dir,
+        cwd=str(working_dir),
     )
 
     return working_dir.glob("*.deb")

--- a/sb-update
+++ b/sb-update
@@ -12,6 +12,7 @@ from typing import List
 
 UPDATE_FILENAME = 'update.tar.xz'
 SB_DEBS = '/sb-debs'
+SB_DEBS_PATH = pathlib.Path(SB_DEBS)
 LOG_FILE = 'update.log'
 
 
@@ -104,7 +105,6 @@ def add_debs_to_local_repo_from(update_file: pathlib.Path) -> None:
         # Note that we do this _separately_ after the checking, so that we can
         # be somewhat confident that either all the debs that were in the
         # update are all in the repo or none are.
-        SB_DEBS_PATH = pathlib.Path(SB_DEBS)
         for deb_path in found_debs:
             logging.debug("Adding {} to internal repo".format(deb_path.name))
             deb_path.rename(SB_DEBS_PATH / deb_path.name)

--- a/sb-update
+++ b/sb-update
@@ -105,9 +105,7 @@ def add_debs_to_local_repo_from(update_file: pathlib.Path) -> None:
         # be somewhat confident that either all the debs that were in the
         # update are all in the repo or none are.
         for deb_path in found_debs:
-            logging.debug("Adding {} to internal repo".format(
-                os.path.basename(deb_path),
-            ))
+            logging.debug("Adding {} to internal repo".format(deb_path.name))
             shutil.copy(deb_path, SB_DEBS)
 
 

--- a/sb-update
+++ b/sb-update
@@ -45,6 +45,22 @@ def update_and_upgrade():
     subprocess.check_call(['apt', 'upgrade', '-y'], stdout=subprocess.DEVNULL)
 
 
+def validate_deb(deb_path):
+    """
+    Validate that the given path is indeed a debian package.
+
+    Raises ``ValueError`` if the package is not valid.
+    """
+    check_deb = subprocess.call(
+        ['dpkg', '--info', deb_path],
+        stdout=subprocess.DEVNULL,
+    )
+
+    if check_deb != 0:
+        raise ValueError("file {} is not a deb file!".format(deb_path))
+
+
+
 def main():
     options = argument_parser().parse_args()
     logging.basicConfig(
@@ -66,9 +82,6 @@ def main():
 
     logging.debug("Found {} potential packages".format(len(deb_glob)))
     for deb in deb_glob:
-        check_deb = subprocess.call(['dpkg', '--info', deb], stdout=subprocess.DEVNULL)
-        if check_deb != 0:
-            raise ValueError("file {} is not a deb file!".format(deb))
         logging.debug("Adding {} to internal repo".format(os.path.basename(deb)))
         shutil.copy(deb, SB_DEBS)
 

--- a/sb-update
+++ b/sb-update
@@ -106,9 +106,9 @@ def add_debs_to_local_repo_from(update_file: pathlib.Path) -> None:
         # update are all in the repo or none are.
         for deb_path in found_debs:
             logging.debug("Adding {} to internal repo".format(
-                os.path.basename(deb),
+                os.path.basename(deb_path),
             ))
-            shutil.copy(deb, SB_DEBS)
+            shutil.copy(deb_path, SB_DEBS)
 
 
 def main():

--- a/sb-update
+++ b/sb-update
@@ -104,9 +104,10 @@ def add_debs_to_local_repo_from(update_file: pathlib.Path) -> None:
         # Note that we do this _separately_ after the checking, so that we can
         # be somewhat confident that either all the debs that were in the
         # update are all in the repo or none are.
+        SB_DEBS_PATH = pathlib.Path(SB_DEBS)
         for deb_path in found_debs:
             logging.debug("Adding {} to internal repo".format(deb_path.name))
-            shutil.copy(deb_path, SB_DEBS)
+            deb_path.rename(SB_DEBS_PATH / deb_path.name)
 
 
 def main():


### PR DESCRIPTION
This uses a temporary directory for extraction, along with introducing some more structure to the extraction logic (and using `pathlib.Path` for type clarity).

Fixes #14.