### PR TITLE
CI linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,12 @@ jobs:
     steps:
       - checkout
       - run: python3 -m venv venv
+      - run: venv/bin/pip install -r script/linting/requirements.txt
       - run: venv/bin/pip install -r script/typing/requirements.txt
+      - run:
+          command: script/linting/lint
+          environment:
+            FLAKE8: venv/bin/flake8
       - run:
           command: script/typing/check
           environment:

--- a/runusb
+++ b/runusb
@@ -6,7 +6,7 @@ import re
 import select
 import subprocess
 from enum import Enum
-from typing import Callable, Iterator, NamedTuple
+from typing import Callable, Dict, Iterator, NamedTuple  # noqa: F401
 
 TypeOpenHandler = Callable[[str], subprocess.Popen]
 TypeCloseHandler = Callable[[str, subprocess.Popen], None]

--- a/runusb
+++ b/runusb
@@ -170,16 +170,16 @@ class AutorunProcessRegistry(object):
     TYPE_HANDLERS = {
         USBType.ROBOT: open_run_robot_code_process,
         USBType.UPDATE: open_update_robot_process
-    } # type: Dict[USBType, TypeOpenHandler]
+    }  # type: Dict[USBType, TypeOpenHandler]
 
     TYPE_CLOSE_HANDLER = {
         USBType.ROBOT: kill_robot_process,
         USBType.UPDATE: noop_close
-    } # type: Dict[USBType, TypeCloseHandler]
+    }  # type: Dict[USBType, TypeCloseHandler]
 
     def __init__(self) -> None:
-        self.mountpoint_processes = {} # type: Dict[str, subprocess.Popen]
-        self.mountpoint_types = {} # type: Dict[str, USBType]
+        self.mountpoint_processes = {}  # type: Dict[str, subprocess.Popen]
+        self.mountpoint_types = {}  # type: Dict[str, USBType]
 
     def update_filesystems(self, mountpoints: Iterator[Mountpoint]) -> None:
         actual_mountpoint_paths = {
@@ -262,7 +262,7 @@ def main():
     except KeyboardInterrupt:
         # Tell the registry that all filesystems were unmounted, which has the
         # effect of making it do cleanup.
-        registry.update_filesystems([]) # type: ignore
+        registry.update_filesystems([])  # type: ignore
 
 
 if __name__ == '__main__':

--- a/runusb
+++ b/runusb
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 
 import logging
-from collections import namedtuple
-import select
-from typing import Callable, Dict, Iterator, List, NamedTuple
-from enum import Enum
 import os
-import subprocess
 import re
+import select
+import subprocess
+from enum import Enum
+from typing import Callable, Iterator, NamedTuple
 
 TypeOpenHandler = Callable[[str], subprocess.Popen]
 TypeCloseHandler = Callable[[str, subprocess.Popen], None]

--- a/runusb
+++ b/runusb
@@ -108,7 +108,7 @@ def open_update_robot_process(path: str) -> subprocess.Popen:
 def open_run_robot_code_process(path: str) -> subprocess.Popen:
     command = [
         'systemd-nspawn',
-        '--private-network'
+        '--private-network',
     ]
 
     # Specify the root directory for the nspawn container
@@ -166,12 +166,12 @@ def noop_close(path, process):
 class AutorunProcessRegistry(object):
     TYPE_HANDLERS = {
         USBType.ROBOT: open_run_robot_code_process,
-        USBType.UPDATE: open_update_robot_process
+        USBType.UPDATE: open_update_robot_process,
     }  # type: Dict[USBType, TypeOpenHandler]
 
     TYPE_CLOSE_HANDLER = {
         USBType.ROBOT: kill_robot_process,
-        USBType.UPDATE: noop_close
+        USBType.UPDATE: noop_close,
     }  # type: Dict[USBType, TypeCloseHandler]
 
     def __init__(self) -> None:

--- a/runusb
+++ b/runusb
@@ -101,10 +101,7 @@ class FSTabReader(object):
 
 
 def open_update_robot_process(path: str) -> subprocess.Popen:
-    command = [
-        'sb-update',
-        path
-    ]
+    command = ['sb-update', path]
     return subprocess.Popen(command, stdin=subprocess.DEVNULL)
 
 

--- a/runusb
+++ b/runusb
@@ -22,9 +22,10 @@ UPDATE_FILENAME = 'update.tar.xz'
 ROBOTD_LOCATION = '/var/robotd'
 
 
-class Mountpoint(NamedTuple):
-    mountpoint: str
-    filesystem: str
+Mountpoint = NamedTuple('Mountpoint', [
+    ('mountpoint', str),
+    ('filesystem', str),
+])
 
 
 VERBOTEN_FILESYSTEMS = (

--- a/sb-update
+++ b/sb-update
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
 
 import argparse
+import logging
 import os
 import pathlib
 import subprocess
 import tempfile
-import shutil
-import logging
-
 from typing import List
 
 UPDATE_FILENAME = 'update.tar.xz'

--- a/sb-update
+++ b/sb-update
@@ -114,8 +114,8 @@ def main():
         level=logging.DEBUG,
         handlers=[
             logging.FileHandler(os.path.join(options.path, LOG_FILE)),
-            logging.StreamHandler()
-        ]
+            logging.StreamHandler(),
+        ],
     )
     update_file = pathlib.Path(os.path.join(options.path, UPDATE_FILENAME))
 

--- a/script/linting/lint
+++ b/script/linting/lint
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ -z "$FLAKE8" ]; then
+    FLAKE8=flake8
+fi
+exec "$FLAKE8" runusb sb-update

--- a/script/linting/requirements.txt
+++ b/script/linting/requirements.txt
@@ -1,0 +1,4 @@
+flake8
+flake8-commas
+flake8-comprehensions
+flake8-isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,25 @@
+[flake8]
+exclude =
+    .eggs,
+    .git,
+    .pybuild,
+    __pycache__,
+    build,
+    debian,
+    script
+
+# try to keep it below 80, but this allows us to push it a bit when needed.
+max_line_length = 90
+
+
+[isort]
+atomic = true
+balanced_wrapping = true
+
+default_section = THIRDPARTY
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+
+
 [mypy]
 # global
 warn_incomplete_stub = True


### PR DESCRIPTION
Adds CI linting and some small tidyups.

Note: this deliberately _doesn't_ use `flake8-mypy` as I'm finding that `mypy` is quite slow, even on a small codebase such as this. In turn that makes the editor experience suboptimal as the quick linter feedback from just running flake8 on its own is preferable.

For clarity: my editor also separately runs mypy as well, so I don't mind that we have two check commands to use (though I can see that others might find that frustrating). I'm open to adding a wrapper which does both or editing my editor config to disable `flake8-mypy` if others would prefer the checks be combined.