### PR TITLE
Simplify compression when rebuilding the apt repo

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,6 @@ Depends: ${misc:Depends},
          systemd-sysv,
          tar,
          usbmount (>= 0.0.24),
-         xz-utils,
 Description: Automagic running of USB sticks
  Runs .autorun files from mounted USB sticks - or other filesystems -
  automatically, and safely containerised.

--- a/sb-update
+++ b/sb-update
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import lzma
 import pathlib
 import subprocess
 import tempfile
@@ -30,21 +31,12 @@ def argument_parser():
 def rebuild_apt_repo():
     logging.debug("Rebuilding apt repo")
 
-    with (SB_DEBS_PATH / 'Packages.xz').open('wb') as packages_xz:
-        scanpackages_process = subprocess.Popen(
+    with lzma.open(SB_DEBS_PATH / 'Packages.xz', mode='wb') as packages_xz:
+        subprocess.check_call(
             ['dpkg-scanpackages', '.', '/dev/null'],
             cwd=SB_DEBS,
-            stdout=subprocess.PIPE,
-        )
-        subprocess.check_call(
-            ['xz', '-3', '-'],
-            stdin=scanpackages_process.stdout,
             stdout=packages_xz,
         )
-        retcode = scanpackages_process.wait()
-
-        if retcode:
-            raise subprocess.CalledProcessError(retcode, 'dpkg-scanpackages')
 
 
 def update_and_upgrade():

--- a/sb-update
+++ b/sb-update
@@ -2,7 +2,7 @@
 
 import argparse
 import logging
-import lzma
+import lzma  # type: ignore
 import pathlib
 import subprocess
 import tempfile


### PR DESCRIPTION
As pointed out by @kierdavis in https://github.com/sourcebots/runusb/pull/22#discussion_r163650254, python has an [lzma](https://docs.python.org/3.5/library/lzma.html) module which provides `xz` compression meaning that we don't need to call out to another process for this.