### PR TITLE
Decode the output returned by subprocess.check_output before printing it

### DIFF
--- a/sb-update
+++ b/sb-update
@@ -62,9 +62,8 @@ def update_and_upgrade():
             base_command + ('update', '--yes'),
             stdout=subprocess.DEVNULL,
         )
-        logging.debug(
-            subprocess.check_output(base_command + ('upgrade', '--assume-no')),
-        )
+        output = subprocess.check_output(base_command + ('upgrade', '--assume-no'))
+        logging.debug(output.decode('utf-8', errors='replace'))
 
         logging.debug("Performing update")
         subprocess.check_call(


### PR DESCRIPTION
`subprocess.check_output` returns a `bytes`. If this is logged directly
it is converted using `repr` and so appears all on one line, as in the
log extract in this comment:
https://github.com/sourcebots/robot-api/issues/49#issuecomment-362643552)

Decoding the output into a `str` should cause it to be displayed
properly. Unicode decoding errors are handled by inserting a
Unicode Replacement Character (U+FFFD) rather than raising an
exception.