### PR TITLE
 Also log the SHA1 of the update file 

### DIFF
--- a/sb-update
+++ b/sb-update
@@ -143,18 +143,22 @@ def main():
             logging.StreamHandler(),
         ],
     )
-    update_file = options.path / UPDATE_FILENAME
+    try:
+        update_file = options.path / UPDATE_FILENAME
 
-    logging.info("Starting updates from {}".format(update_file))
-    add_debs_to_local_repo_from(update_file)
+        logging.info("Starting updates from {}".format(update_file))
+        add_debs_to_local_repo_from(update_file)
 
-    update_file.unlink()
+        update_file.unlink()
 
-    rebuild_apt_repo()
-    update_and_upgrade()
+        rebuild_apt_repo()
+        update_and_upgrade()
 
-    logging.info("Upgrade complete, rebooting.")
-    subprocess.check_call(["reboot"])
+        logging.info("Upgrade complete, rebooting.")
+        subprocess.check_call(["reboot"])
+    except Exception:
+        logging.exception("Upgrade failed")
+        raise
 
 
 if __name__ == '__main__':

--- a/sb-update
+++ b/sb-update
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import hashlib
 import logging
 import lzma  # type: ignore
 import pathlib
@@ -70,6 +71,10 @@ def update_and_upgrade():
             base_command + ('upgrade', '--yes'),
             stdout=subprocess.DEVNULL,
         )
+
+
+def hash_file(path: pathlib.Path) -> str:
+    return hashlib.sha1(path.read_bytes()).hexdigest()
 
 
 def validate_deb(deb_path: pathlib.Path) -> None:
@@ -146,7 +151,10 @@ def main():
     try:
         update_file = options.path / UPDATE_FILENAME
 
-        logging.info("Starting updates from {}".format(update_file))
+        logging.info("Starting updates from {} ({})".format(
+            update_file,
+            hash_file(update_file),
+        ))
         add_debs_to_local_repo_from(update_file)
 
         update_file.unlink()


### PR DESCRIPTION
This is intended to avoid needing to ask which version of the update file was used in the event that things go wrong.

This is also useful to clarify log files which contain several sequential updates (the logger somewhat sensibly opens the log file in append mode).

The interesting commit here is 7ca78b5; I've based this on top of #32 to avoid conflicts.