### PR TITLE
Fix sb-update

### DIFF
--- a/sb-update
+++ b/sb-update
@@ -57,6 +57,7 @@ def update_and_upgrade():
         mode='w',
     ) as source_list:
         source_list.write('deb [trusted=yes] file:{} ./\n'.format(SB_DEBS))
+        source_list.flush()
 
         # Tell apt-get to only consider the local repo we've put our updates into
         base_command = (

--- a/sb-update
+++ b/sb-update
@@ -53,6 +53,8 @@ def rebuild_apt_repo():
 
 def check_output_with_log_on_error(
     command: Sequence[str],
+    *,
+    expected_returncode: int=0
 ) -> str:
     logging.debug("Running {!r}".format(command))
     try:
@@ -62,8 +64,14 @@ def check_output_with_log_on_error(
             stderr=subprocess.STDOUT,
         ).strip()
 
+        if expected_returncode != 0:
+            raise subprocess.CalledProcessError(0, command, output)
+
         return output
     except subprocess.CalledProcessError as ex:
+        if ex.returncode == expected_returncode:
+            return ex.output
+
         logging.error("Command {!r} failed:\n{}".format(
             command,
             ex.output,
@@ -93,6 +101,10 @@ def update_and_upgrade():
 
         upgrade_summary = check_output_with_log_on_error(
             base_command + ('upgrade', '--assume-no'),
+            # Adding '--assume-no' causes an Abort exit, which has a non-zero
+            # exit code. Unfortunately there doesn't seem to be an alternative
+            # mechanism to list the available updates via apt-get.
+            expected_returncode=1,
         )
         logging.debug(upgrade_summary)
 

--- a/sb-update
+++ b/sb-update
@@ -7,7 +7,7 @@ import lzma  # type: ignore
 import pathlib
 import subprocess
 import tempfile
-from typing import List
+from typing import List, Sequence
 
 UPDATE_FILENAME = 'update.tar.xz'
 SB_DEBS = '/sb-debs'
@@ -51,6 +51,26 @@ def rebuild_apt_repo():
         ))
 
 
+def check_output_with_log_on_error(
+    command: Sequence[str],
+) -> str:
+    logging.debug("Running {!r}".format(command))
+    try:
+        output = subprocess.check_output(
+            command,
+            universal_newlines=True,
+            stderr=subprocess.STDOUT,
+        ).strip()
+
+        return output
+    except subprocess.CalledProcessError as ex:
+        logging.error("Command {!r} failed:\n{}".format(
+            command,
+            ex.output,
+        ))
+        raise
+
+
 def update_and_upgrade():
     with tempfile.NamedTemporaryFile(
         suffix='.sourcebots.list',
@@ -69,18 +89,15 @@ def update_and_upgrade():
         )
 
         logging.debug("Updating repo")
-        subprocess.check_call(
-            base_command + ('update', '--yes'),
-            stdout=subprocess.DEVNULL,
+        check_output_with_log_on_error(base_command + ('update', '--yes'))
+
+        upgrade_summary = check_output_with_log_on_error(
+            base_command + ('upgrade', '--assume-no'),
         )
-        output = subprocess.check_output(base_command + ('upgrade', '--assume-no'))
-        logging.debug(output.decode('utf-8', errors='replace'))
+        logging.debug(upgrade_summary)
 
         logging.debug("Performing update")
-        subprocess.check_call(
-            base_command + ('upgrade', '--yes'),
-            stdout=subprocess.DEVNULL,
-        )
+        check_output_with_log_on_error(base_command + ('upgrade', '--yes'))
 
 
 def hash_file(path: pathlib.Path) -> str:

--- a/sb-update
+++ b/sb-update
@@ -62,7 +62,7 @@ def check_output_with_log_on_error(
             command,
             universal_newlines=True,
             stderr=subprocess.STDOUT,
-        ).strip()
+        ).strip()  # type: str # (universal_newlines does the conversion for us)
 
         if expected_returncode != 0:
             raise subprocess.CalledProcessError(0, command, output)
@@ -70,7 +70,10 @@ def check_output_with_log_on_error(
         return output
     except subprocess.CalledProcessError as ex:
         if ex.returncode == expected_returncode:
-            return ex.output
+            # Mypy thinks that ex.output is Any. Strictly ex.output is
+            # Optional[str], however our use-cases mean that it's actually
+            # always a str.
+            return ex.output  # type: ignore
 
         logging.error("Command {!r} failed:\n{}".format(
             command,

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,10 @@ exclude =
     build,
     debian,
     script
+ignore =
+    # don't require commas in places that only Python 3.6 requires them (we're
+    # on Python 3.5)
+    C816
 
 # try to keep it below 80, but this allows us to push it a bit when needed.
 max_line_length = 90


### PR DESCRIPTION
This fixes various issues with `sb-update` from testing on a real Pi. (Side note: we _really_ need a CI and some automated tests). The strategy I used for these was to have an update file with a robot-api update to hand and then run `sb-update` directly, fixing issues as I went.

Issues fixed:
- as the custom source.list we use now is a tempfile, we write the necessary content as part of its creation. As a result we need to flush that to disk before we can rely on other processes seeing that content (ac0db2c)
- the `--assume-no` option to `apt-get` results in the processing exiting with `Abort.` and an exit code of `1`, which we need to cope with

Along the way I also improve the logging a little.