### PR TITLE
Don't self-restart on upgrades

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,10 @@
 	dh $@ --with systemd
 
 override_dh_systemd_start:
-	dh_systemd_start --restart-after-upgrade runusb.service
+	# Don't restart on upgrade as that causes the upgrade process to get killed
+	# mid-update; instead rely on sb-update rebooting the system after updating.
+	# Changing this? Also change that configuration in `sb-update`.
+	dh_systemd_start --no-restart-on-upgrade runusb.service
 
 override_dh_install:
 	find debian/ -name __pycache__ -type d | xargs -r rm -r

--- a/sb-update
+++ b/sb-update
@@ -27,6 +27,10 @@ def argument_parser():
         type=pathlib.Path,
     )
 
+    # Note: the `runusb` package is configured not to be restarted as part of
+    # the upgrade process, instead relying on that being handled by the system
+    # being rebooted afterwards.
+    # Changing this? Also change that configuration in `debian/rules`.
     parser.add_argument(
         '--no-reboot',
         help="Don't reboot after installing updates (useful for debugging this script)",


### PR DESCRIPTION
This changes the `systemd` integration such that we don't restart the `runusb` service on upgrade, instead relying on the fact that `sb-update` reboots the Pi once the upgrades are complete.

This fixes #41.

The log from a test install follows. In the following, both 2018.4 and 2018.5 are built from this branch (specifically a8245da843d9d832e7517e776091daced0d92f86); their version numbers changed only to ensure that the upgrade was picked up each time. I'd installed 2018.4 manually first, then created an update file around 2018.5, put that on a USB stick and plugged it in. The log was pulled from the `update.log` file on the USB stick after the Pi rebooted.
```
INFO:root:Starting updates from /media/usb0/update.tar.xz (a160ea470f0d16fa540a7181f189e0f0fa648434)
DEBUG:root:Found 1 potential packages
DEBUG:root:Adding runusb_2018.5.0_all.deb to internal repo
DEBUG:root:Rebuilding apt repo
DEBUG:root:Updating repo
DEBUG:root:Running ('apt-get', '--option', 'Dir::Etc::SourceParts=', '--option', 'Dir::Etc::SourceList=/tmp/tmp27c68wvk.sourcebots.list', 'update', '--yes')
DEBUG:root:Dry run
DEBUG:root:Running ('apt-get', '--option', 'Dir::Etc::SourceParts=', '--option', 'Dir::Etc::SourceList=/tmp/tmp27c68wvk.sourcebots.list', 'upgrade', '--dry-run')
DEBUG:root:Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
The following package was automatically installed and is no longer required:
  libusb-1.0-0-dev
Use 'apt autoremove' to remove it.
The following packages will be upgraded:
  runusb
1 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Inst runusb [2018.4.0] (2018.5.0 localhost [all])
Conf runusb (2018.5.0 localhost [all])
DEBUG:root:Performing update
DEBUG:root:Running ('apt-get', '--option', 'Dir::Etc::SourceParts=', '--option', 'Dir::Etc::SourceList=/tmp/tmp27c68wvk.sourcebots.list', 'upgrade', '--yes')
INFO:root:Upgrade complete.
INFO:root:Rebooting...
```