### PR TITLE
Fix linting error

### DIFF
--- a/runusb
+++ b/runusb
@@ -193,15 +193,15 @@ class AutorunProcessRegistry(object):
 
         # Handle newly detected filesystems
         for new_mountpoint_path in (
-                actual_mountpoint_paths -
-                expected_mountpoint_paths
+            actual_mountpoint_paths
+            - expected_mountpoint_paths
         ):
             self._detect_new_mountpoint_path(new_mountpoint_path)
 
         # Handle now-dead filesystems
         for old_mountpoint_path in (
-                expected_mountpoint_paths -
-                actual_mountpoint_paths
+            expected_mountpoint_paths
+            - actual_mountpoint_paths
         ):
             self._detect_dead_mountpoint_path(old_mountpoint_path)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,8 @@ ignore =
     # don't require commas in places that only Python 3.6 requires them (we're
     # on Python 3.5)
     C816
+    # W503 and W504 conflict; ignore the one that disagrees with recent PEP8.
+    W503
 
 # try to keep it below 80, but this allows us to push it a bit when needed.
 max_line_length = 90


### PR DESCRIPTION
For some reason W503 (line break before binary operator) and W504
(line break after binary operator) were both enabled, meaning that
breaking a binary operator expression across multiple lines was a
violation no matter how you format it. I've disabled W503 and kept
W504 in accordance with PEP8. See description of W504 for more
details: https://lintlyci.github.io/Flake8Rules/rules/W504.html