### PR TITLE
Pass metadata location to robot code

### DIFF
--- a/runusb
+++ b/runusb
@@ -14,6 +14,7 @@ PROC_FILE = '/proc/mounts'
 ROBOT_FILE = 'main.py'
 SPAWN_IMAGE = '/mnt/rootmirror'
 UPDATE_FILENAME = 'update.tar.xz'
+METADATA_FILENAME = 'metadata.json'
 
 
 Mountpoint = NamedTuple('Mountpoint', [
@@ -38,6 +39,7 @@ VERBOTEN_FILESYSTEMS = (
 class USBType(Enum):
     ROBOT = 'ROBOT'
     UPDATE = 'UPDATE'
+    METADATA = 'METADATA'
     INVALID = 'INVALID'  # We dont care about this drive
 
 
@@ -53,6 +55,10 @@ def detect_usb_type(mountpoint: str) -> USBType:
     # Check for the existence of the robot code
     if os.path.exists(os.path.join(mountpoint, ROBOT_FILE)):
         return USBType.ROBOT
+
+    # Check for existence of a metadata file
+    if os.path.exists(os.path.join(mountpoint, METADATA_FILENAME)):
+        return USBType.METADATA
 
     return USBType.INVALID
 
@@ -135,10 +141,19 @@ class UpdateUSBHandler(USBHandler):
         pass
 
 
+class MetadataUSBHandler(USBHandler):
+    def __init__(self, registry: 'AutorunProcessRegistry', mountpoint_path: str):
+        pass  # Nothing to do.
+
+    def close(self) -> None:
+        pass  # Nothing to do.
+
+
 class AutorunProcessRegistry(object):
     TYPE_HANDLERS = {
         USBType.ROBOT: RobotUSBHandler,
         USBType.UPDATE: UpdateUSBHandler,
+        USBType.METADATA: MetadataUSBHandler,
     }  # type: Dict[USBType, Type[USBHandler]]
 
     def __init__(self) -> None:

--- a/runusb
+++ b/runusb
@@ -6,7 +6,7 @@ import select
 import subprocess
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from typing import Dict, Iterator, NamedTuple, Type  # noqa: F401
+from typing import Dict, Iterator, NamedTuple, Optional, Type  # noqa: F401
 
 LOGGER = logging.getLogger('runusb')
 
@@ -109,13 +109,36 @@ class USBHandler(metaclass=ABCMeta):
 
 class RobotUSBHandler(USBHandler):
     def __init__(self, registry: 'AutorunProcessRegistry', mountpoint_path: str):
+        env = dict(os.environ)
+        metadata_path = self._find_metadata_usb(registry)
+        if metadata_path is not None:
+            env["SBOT_METADATA_PATH"] = metadata_path
+
         self.process = subprocess.Popen(
             ["python3", "-u", ROBOT_FILE],
             stdin=subprocess.DEVNULL,
             stdout=open(os.path.join(mountpoint_path, "log.txt"), "w"),
             stderr=subprocess.STDOUT,
             cwd=mountpoint_path,
+            env=env,
         )
+
+    def _find_metadata_usb(self, registry: 'AutorunProcessRegistry') -> Optional[str]:
+        paths = [
+            path
+            for path, usb_type in registry.mountpoint_types.items()
+            if usb_type == USBType.METADATA
+        ]
+        if not paths:
+            return None
+        if len(paths) > 1:
+            LOGGER.warn(
+                "Multiple metadata USBs detected (this is not supported!): %s",
+                ", ".join(paths),
+            )
+        path = paths[0]
+        LOGGER.debug("Detected metadata at %s", path)
+        return path
 
     def close(self) -> None:
         self.process.terminate()

--- a/runusb
+++ b/runusb
@@ -4,12 +4,9 @@ import logging
 import os
 import select
 import subprocess
+from abc import ABCMeta, abstractmethod
 from enum import Enum
-from typing import Callable, Dict, Iterator, NamedTuple  # noqa: F401
-
-TypeOpenHandler = Callable[[str], subprocess.Popen]
-TypeCloseHandler = Callable[[str, subprocess.Popen], None]
-
+from typing import Dict, Iterator, NamedTuple, Type  # noqa: F401
 
 LOGGER = logging.getLogger('runusb')
 
@@ -94,53 +91,58 @@ class FSTabReader(object):
         return bool(changed)
 
 
-def open_update_robot_process(path: str) -> subprocess.Popen:
-    return subprocess.Popen(
-        ['sb-update', path],
-        stdin=subprocess.DEVNULL,
-    )
-
-
-def open_run_robot_code_process(path: str) -> subprocess.Popen:
-    return subprocess.Popen(
-        ["python3", "-u", ROBOT_FILE],
-        stdin=subprocess.DEVNULL,
-        stdout=open(os.path.join(path, "log.txt"), "w"),
-        stderr=subprocess.STDOUT,
-        cwd=path,
-    )
-
-
-def kill_robot_process(path: str, process: subprocess.Popen) -> None:
-    process.terminate()
-    try:
-        process.communicate(timeout=5)
-    except subprocess.TimeoutExpired:
+class USBHandler(metaclass=ABCMeta):
+    @abstractmethod
+    def __init__(self, mountpoint_path: str):
         pass
-    process.kill()
+
+    @abstractmethod
+    def close(self) -> None:
+        pass
 
 
-def noop_close(path, process):
-    """
-        We don't actually want to kill in the case of the update process.
-        Could lead to the robot in a broken state!
-    """
-    pass
+class RobotUSBHandler(USBHandler):
+    def __init__(self, mountpoint_path: str):
+        self.process = subprocess.Popen(
+            ["python3", "-u", ROBOT_FILE],
+            stdin=subprocess.DEVNULL,
+            stdout=open(os.path.join(mountpoint_path, "log.txt"), "w"),
+            stderr=subprocess.STDOUT,
+            cwd=mountpoint_path,
+        )
+
+    def close(self) -> None:
+        self.process.terminate()
+        try:
+            self.process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+        self.process.kill()
+
+
+class UpdateUSBHandler(USBHandler):
+    def __init__(self, mountpoint_path: str):
+        self.process = subprocess.Popen(
+            ['sb-update', mountpoint_path],
+            stdin=subprocess.DEVNULL,
+        )
+
+    def close(self) -> None:
+        """
+            We don't actually want to kill in the case of the update process.
+            Could lead to the robot in a broken state!
+        """
+        pass
 
 
 class AutorunProcessRegistry(object):
     TYPE_HANDLERS = {
-        USBType.ROBOT: open_run_robot_code_process,
-        USBType.UPDATE: open_update_robot_process,
-    }  # type: Dict[USBType, TypeOpenHandler]
-
-    TYPE_CLOSE_HANDLER = {
-        USBType.ROBOT: kill_robot_process,
-        USBType.UPDATE: noop_close,
-    }  # type: Dict[USBType, TypeCloseHandler]
+        USBType.ROBOT: RobotUSBHandler,
+        USBType.UPDATE: UpdateUSBHandler,
+    }  # type: Dict[USBType, Type[USBHandler]]
 
     def __init__(self) -> None:
-        self.mountpoint_processes = {}  # type: Dict[str, subprocess.Popen]
+        self.mountpoint_handlers = {}  # type: Dict[str, USBHandler]
         self.mountpoint_types = {}  # type: Dict[str, USBType]
 
     def update_filesystems(self, mountpoints: Iterator[Mountpoint]) -> None:
@@ -151,7 +153,7 @@ class AutorunProcessRegistry(object):
         }
 
         expected_mountpoint_paths = {
-            x for x in self.mountpoint_processes.keys()
+            x for x in self.mountpoint_handlers.keys()
         }
 
         # Handle newly detected filesystems
@@ -171,20 +173,18 @@ class AutorunProcessRegistry(object):
     def _detect_new_mountpoint_path(self, path: str) -> None:
         LOGGER.info("Found new mountpoint: %s", path)
         usb_type = detect_usb_type(path)
-        type_handler = self.TYPE_HANDLERS[usb_type]
-        process = type_handler(path)
-        LOGGER.info("  -> launched process")
-        self.mountpoint_processes[path] = process
+        handler_class = self.TYPE_HANDLERS[usb_type]
+        handler = handler_class(path)
+        LOGGER.info("  -> launched handler")
+        self.mountpoint_handlers[path] = handler
         self.mountpoint_types[path] = usb_type
 
     def _detect_dead_mountpoint_path(self, path: str) -> None:
         LOGGER.info("Lost mountpoint: %s", path)
-        usb_type = self.mountpoint_types[path]
-        process = self.mountpoint_processes[path]
-        close_handler = self.TYPE_CLOSE_HANDLER[usb_type]
-        close_handler(path, process)
-        LOGGER.info("  -> closed process")
-        del self.mountpoint_processes[path]
+        handler = self.mountpoint_handlers[path]
+        handler.close()
+        LOGGER.info("  -> closed handler")
+        del self.mountpoint_handlers[path]
         del self.mountpoint_types[path]
 
     def _is_viable_mountpoint(self, mountpoint: Mountpoint) -> bool:

--- a/runusb
+++ b/runusb
@@ -93,7 +93,7 @@ class FSTabReader(object):
 
 class USBHandler(metaclass=ABCMeta):
     @abstractmethod
-    def __init__(self, mountpoint_path: str):
+    def __init__(self, registry: 'AutorunProcessRegistry', mountpoint_path: str):
         pass
 
     @abstractmethod
@@ -102,7 +102,7 @@ class USBHandler(metaclass=ABCMeta):
 
 
 class RobotUSBHandler(USBHandler):
-    def __init__(self, mountpoint_path: str):
+    def __init__(self, registry: 'AutorunProcessRegistry', mountpoint_path: str):
         self.process = subprocess.Popen(
             ["python3", "-u", ROBOT_FILE],
             stdin=subprocess.DEVNULL,
@@ -121,7 +121,7 @@ class RobotUSBHandler(USBHandler):
 
 
 class UpdateUSBHandler(USBHandler):
-    def __init__(self, mountpoint_path: str):
+    def __init__(self, registry: 'AutorunProcessRegistry', mountpoint_path: str):
         self.process = subprocess.Popen(
             ['sb-update', mountpoint_path],
             stdin=subprocess.DEVNULL,
@@ -174,7 +174,7 @@ class AutorunProcessRegistry(object):
         LOGGER.info("Found new mountpoint: %s", path)
         usb_type = detect_usb_type(path)
         handler_class = self.TYPE_HANDLERS[usb_type]
-        handler = handler_class(path)
+        handler = handler_class(self, path)
         LOGGER.info("  -> launched handler")
         self.mountpoint_handlers[path] = handler
         self.mountpoint_types[path] = usb_type


### PR DESCRIPTION
Closes #46.

This adds a new type of USB stick, `METADATA`, distinguished by having a `metadata.json` in the root of its filesystem. When a robot code USB is later plugged in, the list of mounted USB sticks is scanned for one of type `METADATA`, and its mountpoint is passed to the robot code via the `SBOT_METADATA_PATH` environment variable.