### PR TITLE
Work around servo board pink light bug

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Depends: ${misc:Depends},
          python3,
          systemd-sysv,
          usbmount (>= 0.0.24),
+         uhubctl,
 Description: Automagic running of USB sticks
  Runs .autorun files from mounted USB sticks - or other filesystems -
  automatically, and safely containerised.

--- a/debian/control
+++ b/debian/control
@@ -14,8 +14,8 @@ Depends: ${misc:Depends},
          dpkg-dev,
          python3,
          systemd-sysv,
-         usbmount (>= 0.0.24),
          uhubctl,
+         usbmount (>= 0.0.24),
 Description: Automagic running of USB sticks
  Runs .autorun files from mounted USB sticks - or other filesystems -
  automatically, and safely containerised.

--- a/runusb
+++ b/runusb
@@ -147,6 +147,43 @@ class RobotUSBHandler(USBHandler):
         except subprocess.TimeoutExpired:
             pass
         self.process.kill()
+        self._reset_servo_board()
+
+    def _reset_servo_board(self) -> None:
+        """
+        Due to an outstanding bug in the SR servo board firmware
+        (https://github.com/srobo/servo-v4-fw/issues/7),
+        it crashes when 12V power is removed as the user code process exits,
+        rendering its USB interface unusable until the microcontroller is reset.
+
+        Unfortunately there is no way to reset the microcontroller remotely
+        other than by power-cycling the power provided to it over USB. While a
+        few USB hubs support power-cycling individual ports, neither the
+        Raspberry Pi's internal hub nor the model of external hub we currently
+        use support this, so the best we can do is to power-cycle all of the
+        Raspberry Pi's ports at once. On the upside, it means we don't have to
+        care whereabouts on the bus the servo board is connected.
+
+        To be specific, the Raspberry Pi's internal hub does support some level
+        of per-port switching but not enough to be useful to us: port 1 (which
+        is connected to the builtin Ethernet controller) can be switched
+        independently of ports 2 to 5 (the physical USB ports). Ports 2-5 are
+        switched by telling uhubctl to operate on port 2; telling it to operate
+        on ports 3, 4 or 5 has no effect. See the uhubctl README for more info:
+        https://github.com/mvp/uhubctl
+        """
+        command = [
+            "uhubctl",
+            "--loc", "1-1",  # path to the hub to power cycle (this never changes)
+            "--ports", "2",  # only switch ports 2-5
+            "--action", "cycle",
+            "--delay", "1",  # time to wait before powering back on
+        ]
+        LOGGER.info("power-cycling USB bus to reset servo board (srobo/servo-v4-fw#7)")
+        try:
+            subprocess.run(command, check=True)
+        except BaseException:
+            LOGGER.exception("failed to power-cycle USB bus")
 
 
 class UpdateUSBHandler(USBHandler):


### PR DESCRIPTION
Work around srobo/servo-v4-fw#7 since we can't modify the firmwares of the servo boards we're shipping for the summer school.

Please could someone check that I've added the dependency on `uhubctl` correctly since I am unfamiliar with debian packaging.

See inline comment for details.