### PR TITLE
Remove dh-systemd dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Install through apt:
 * `build-essential`
 * `devscripts`
 * `debhelper`
-* `dh-systemd`
 
 And then run, from the root of the project:
 

--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,7 @@ Source: runusb
 Section: electronics
 Priority: optional
 Maintainer: Alistair Lynn <arplynn@gmail.com>
-Build-Depends: debhelper (>= 9),
-               dh-systemd,
+Build-Depends: debhelper (>= 9.20160709),
 Standards-Version: 3.9.6
 
 Package: runusb


### PR DESCRIPTION
Newer versions of debian/ubuntu include dh-systemd as part of debhelper.