### PR TITLE
Build debian package in CI

### DIFF
--- a/.github/workflows/debuild.yml
+++ b/.github/workflows/debuild.yml
@@ -19,8 +19,11 @@ jobs:
           sudo apt-get install --yes build-essential devscripts debhelper
       - name: Build package
         run: debuild -uc -us
+      - name: Get debian package name
+        run: |
+          echo "runusb_deb_path=$(realpath ../*.deb)" >> $GITHUB_ENV
       - name: Save deb artifact
         uses: actions/upload-artifact@v3
         with:
           name: runusb
-          path: ../*.deb
+          path: ${{ env.runusb_deb_path }}

--- a/.github/workflows/debuild.yml
+++ b/.github/workflows/debuild.yml
@@ -22,8 +22,18 @@ jobs:
       - name: Get debian package name
         run: |
           echo "runusb_deb_path=$(realpath ../*.deb)" >> $GITHUB_ENV
+          echo "runusb_deb_name=$(basename ../*.deb)" >> $GITHUB_ENV
       - name: Save deb artifact
         uses: actions/upload-artifact@v3
         with:
           name: runusb
           path: ${{ env.runusb_deb_path }}
+      - name: Upload deb to release
+        uses: svenstaro/upload-release-action@v2
+        if: github.event_name == 'release'
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ env.runusb_deb_path }}
+          asset_name: ${{ env.runusb_deb_name }}
+          tag: ${{ github.ref }}
+          overwrite: true

--- a/.github/workflows/debuild.yml
+++ b/.github/workflows/debuild.yml
@@ -19,3 +19,8 @@ jobs:
           sudo apt-get install --yes build-essential devscripts debhelper
       - name: Build package
         run: debuild -uc -us
+      - name: Save deb artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: runusb
+          path: ../*.deb

--- a/.github/workflows/debuild.yml
+++ b/.github/workflows/debuild.yml
@@ -1,0 +1,21 @@
+name: Build Debian package
+
+on:
+  release:
+    types: [created]
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  debuild:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes build-essential devscripts debhelper
+      - name: Build package
+        run: debuild -uc -us

--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ Install through apt:
 And then run, from the root of the project:
 
 * `debuild -uc -us`
+
+Alternatively, you can download the prebuilt package from the GitHub releases.


### PR DESCRIPTION
Build the packages in CI, and upload them as part of releases. This saves huge amounts of time building packages as part of the [image build](https://github.com/sourcebots/robot-image).