### PR TITLE
Series of improvements

### DIFF
--- a/runusb
+++ b/runusb
@@ -175,7 +175,6 @@ class RobotUSBHandler(USBHandler):
             pass
         self._send_signal(signal.SIGKILL)
         self._set_leds()
-        self._reset_servo_board()
 
     def _send_signal(self, sig: int) -> None:
         if self.process.poll() is not None:
@@ -202,42 +201,6 @@ class RobotUSBHandler(USBHandler):
             LED_CONTROLLER.green()
         else:
             LED_CONTROLLER.red()
-
-    def _reset_servo_board(self) -> None:
-        """
-        Due to an outstanding bug in the SR servo board firmware
-        (https://github.com/srobo/servo-v4-fw/issues/7),
-        it crashes when 12V power is removed as the user code process exits,
-        rendering its USB interface unusable until the microcontroller is reset.
-
-        Unfortunately there is no way to reset the microcontroller remotely
-        other than by power-cycling the power provided to it over USB. While a
-        few USB hubs support power-cycling individual ports, neither the
-        Raspberry Pi's internal hub nor the model of external hub we currently
-        use support this, so the best we can do is to power-cycle all of the
-        Raspberry Pi's ports at once. On the upside, it means we don't have to
-        care whereabouts on the bus the servo board is connected.
-
-        To be specific, the Raspberry Pi's internal hub does support some level
-        of per-port switching but not enough to be useful to us: port 1 (which
-        is connected to the builtin Ethernet controller) can be switched
-        independently of ports 2 to 5 (the physical USB ports). Ports 2-5 are
-        switched by telling uhubctl to operate on port 2; telling it to operate
-        on ports 3, 4 or 5 has no effect. See the uhubctl README for more info:
-        https://github.com/mvp/uhubctl
-        """
-        command = [
-            "uhubctl",
-            "--loc", "1-1",  # path to the hub to power cycle (this never changes)
-            "--ports", "2",  # only switch ports 2-5
-            "--action", "cycle",
-            "--delay", "1",  # time to wait before powering back on
-        ]
-        LOGGER.info("power-cycling USB bus to reset servo board (srobo/servo-v4-fw#7)")
-        try:
-            subprocess.run(command, check=True)
-        except BaseException:
-            LOGGER.exception("failed to power-cycle USB bus")
 
 
 class MetadataUSBHandler(USBHandler):

--- a/runusb
+++ b/runusb
@@ -102,12 +102,9 @@ def detect_usb_type(mountpoint: str) -> USBType:
         return USBType.METADATA
 
     LOGGER.info(
-        "Disregarding filesystem %s of type %s is not forbidden but lacks "
-        "either %s or %s.",
-        mountpoint.mountpoint,
-        mountpoint.filesystem,
-        ROBOT_FILE,
-        METADATA_FILENAME,
+        f"Disregarding filesystem {mountpoint.mountpoint} of type "
+        f"{mountpoint.filesystem} is not forbidden but lacks either "
+        f"{ROBOT_FILE} or {METADATA_FILENAME} file."
     )
 
     return USBType.INVALID
@@ -247,7 +244,7 @@ class AutorunProcessRegistry(object):
             self._detect_dead_mountpoint_path(old_mountpoint)
 
     def _detect_new_mountpoint_path(self, path: str) -> None:
-        LOGGER.info("Found new mountpoint: %s", path)
+        LOGGER.info(f"Found new mountpoint: {path}")
         usb_type = detect_usb_type(path)
         handler_class = self.TYPE_HANDLERS[usb_type]
         handler = handler_class(path)
@@ -255,7 +252,7 @@ class AutorunProcessRegistry(object):
         self.mountpoint_handlers[path] = handler
 
     def _detect_dead_mountpoint_path(self, path: str) -> None:
-        LOGGER.info("Lost mountpoint: %s", path)
+        LOGGER.info(f"Lost mountpoint: {path}")
         handler = self.mountpoint_handlers[path]
         handler.close()
         LOGGER.info("  -> closed handler")

--- a/runusb
+++ b/runusb
@@ -101,6 +101,15 @@ def detect_usb_type(mountpoint: str) -> USBType:
     if os.path.exists(os.path.join(mountpoint, METADATA_FILENAME)):
         return USBType.METADATA
 
+    LOGGER.info(
+        "Disregarding filesystem %s of type %s is not forbidden but lacks "
+        "either %s or %s.",
+        mountpoint.mountpoint,
+        mountpoint.filesystem,
+        ROBOT_FILE,
+        METADATA_FILENAME,
+    )
+
     return USBType.INVALID
 
 
@@ -255,13 +264,6 @@ class AutorunProcessRegistry(object):
     def _is_viable_mountpoint(self, mountpoint: Mountpoint) -> bool:
         # Drop restricted types
         if mountpoint.filesystem in VERBOTEN_FILESYSTEMS:
-            LOGGER.debug(
-                "Disregarding filesystem %s due to forbidden filesystem "
-                "type %s",
-                mountpoint.mountpoint,
-                mountpoint.filesystem,
-            )
-
             return False
 
         # Sanity: never consider the root filesystem

--- a/runusb
+++ b/runusb
@@ -55,7 +55,7 @@ class LEDController():
     def __init__(self) -> None:
         if IS_PI:
             LOGGER.debug("Configuring LED controller")
-            atexit.register(GPIO.cleanup)
+            atexit.register(GPIO.cleanup)  # type: ignore[attr-defined]
             GPIO.setmode(GPIO.BOARD)
             GPIO.setup([led.value for led in self.LEDs], GPIO.OUT, initial=GPIO.LOW)
 
@@ -92,8 +92,7 @@ def detect_usb_type(mountpoint: str) -> USBType:
     # only mountpoints under MOUNTPOINT_DIR are considered
     if not mountpoint.startswith(MOUNTPOINT_DIR):
         LOGGER.debug(
-            f"Disregarding filesystem {mountpoint} of type "
-            f"{mountpoint.filesystem} is not under {MOUNTPOINT_DIR}.",
+            f"Disregarding filesystem {mountpoint!r}. Is not under {MOUNTPOINT_DIR}.",
         )
         return USBType.INVALID
 
@@ -106,8 +105,7 @@ def detect_usb_type(mountpoint: str) -> USBType:
         return USBType.METADATA
 
     LOGGER.info(
-        f"Disregarding filesystem {mountpoint.mountpoint} of type "
-        f"{mountpoint.filesystem} is not forbidden but lacks either "
+        f"Disregarding filesystem {mountpoint!r}. Is not forbidden but lacks either "
         f"{ROBOT_FILE} or {METADATA_FILENAME} file.",
     )
 

--- a/runusb
+++ b/runusb
@@ -10,7 +10,7 @@ import time
 from abc import ABCMeta, abstractmethod
 from enum import Enum, IntEnum, unique
 from threading import Thread
-from typing import Iterator, NamedTuple, Type  # noqa: F401
+from typing import Iterator, NamedTuple, Type
 
 try:
     import RPi.GPIO as GPIO

--- a/runusb
+++ b/runusb
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import atexit
 import logging
 import os
 import select
@@ -54,7 +55,7 @@ class LEDController():
     def __init__(self) -> None:
         if IS_PI:
             LOGGER.debug("Configuring LED controller")
-            GPIO.setwarnings(False)
+            atexit.register(GPIO.cleanup)
             GPIO.setmode(GPIO.BOARD)
             GPIO.setup([led.value for led in self.LEDs], GPIO.OUT, initial=GPIO.LOW)
 

--- a/runusb
+++ b/runusb
@@ -93,7 +93,7 @@ def detect_usb_type(mountpoint: str) -> USBType:
     if not mountpoint.startswith(MOUNTPOINT_DIR):
         LOGGER.debug(
             f"Disregarding filesystem {mountpoint} of type "
-            f"{mountpoint.filesystem} is not under {MOUNTPOINT_DIR}."
+            f"{mountpoint.filesystem} is not under {MOUNTPOINT_DIR}.",
         )
         return USBType.INVALID
 
@@ -108,7 +108,7 @@ def detect_usb_type(mountpoint: str) -> USBType:
     LOGGER.info(
         f"Disregarding filesystem {mountpoint.mountpoint} of type "
         f"{mountpoint.filesystem} is not forbidden but lacks either "
-        f"{ROBOT_FILE} or {METADATA_FILENAME} file."
+        f"{ROBOT_FILE} or {METADATA_FILENAME} file.",
     )
 
     return USBType.INVALID

--- a/runusb
+++ b/runusb
@@ -108,13 +108,6 @@ class FSTabReader(object):
     def __init__(self) -> None:
         self.handle = open(PROC_FILE)
 
-    def __enter__(self) -> 'FSTabReader':
-        self.handle.__enter__()
-        return self
-
-    def __exit__(self, *args, **kwargs):
-        return self.handle.__exit__(*args, **kwargs)
-
     def close(self) -> None:
         self.handle.close()
 

--- a/runusb
+++ b/runusb
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import logging
 import os
@@ -9,7 +10,7 @@ import time
 from abc import ABCMeta, abstractmethod
 from enum import Enum, IntEnum, unique
 from threading import Thread
-from typing import Dict, Iterator, NamedTuple, Optional, Type  # noqa: F401
+from typing import Iterator, NamedTuple, Type  # noqa: F401
 
 try:
     import RPi.GPIO as GPIO
@@ -26,10 +27,9 @@ MOUNTPOINT_DIR = '/media'  # the directory under which all USBs will be mounted
 METADATA_FILENAME = 'metadata.json'
 
 
-Mountpoint = NamedTuple('Mountpoint', [
-    ('mountpoint', str),
-    ('filesystem', str),
-])
+class Mountpoint(NamedTuple):
+    mountpoint: str
+    filesystem: str
 
 
 VERBOTEN_FILESYSTEMS = (
@@ -108,14 +108,14 @@ class FSTabReader(object):
     def __init__(self) -> None:
         self.handle = open(PROC_FILE)
 
-    def __enter__(self):
+    def __enter__(self) -> 'FSTabReader':
         self.handle.__enter__()
         return self
 
     def __exit__(self, *args, **kwargs):
         return self.handle.__exit__(*args, **kwargs)
 
-    def close(self):
+    def close(self) -> None:
         self.handle.close()
 
     def read(self) -> Iterator[Mountpoint]:
@@ -129,7 +129,7 @@ class FSTabReader(object):
                 filesystem=filesystem,
             )
 
-    def watch(self, timeout=None):
+    def watch(self, timeout=None) -> bool:
         _, _, changed = select.select([], [], [self.handle], timeout)
 
         if changed:
@@ -140,7 +140,7 @@ class FSTabReader(object):
 
 class USBHandler(metaclass=ABCMeta):
     @abstractmethod
-    def __init__(self, mountpoint_path: str):
+    def __init__(self, mountpoint_path: str) -> None:
         pass
 
     @abstractmethod
@@ -149,7 +149,7 @@ class USBHandler(metaclass=ABCMeta):
 
 
 class RobotUSBHandler(USBHandler):
-    def __init__(self, mountpoint_path: str):
+    def __init__(self, mountpoint_path: str) -> None:
         LED_CONTROLLER.yellow()
         env = dict(os.environ)
         env["SBOT_METADATA_PATH"] = MOUNTPOINT_DIR
@@ -204,7 +204,7 @@ class RobotUSBHandler(USBHandler):
         # Start clean-up
         self.close()
 
-    def _set_leds(self):
+    def _set_leds(self) -> None:
         if self.process.returncode == 0:
             LED_CONTROLLER.green()
         else:
@@ -248,7 +248,7 @@ class RobotUSBHandler(USBHandler):
 
 
 class MetadataUSBHandler(USBHandler):
-    def __init__(self, mountpoint_path: str):
+    def __init__(self, mountpoint_path: str) -> None:
         pass  # Nothing to do.
 
     def close(self) -> None:
@@ -256,14 +256,14 @@ class MetadataUSBHandler(USBHandler):
 
 
 class AutorunProcessRegistry(object):
-    TYPE_HANDLERS = {
+    TYPE_HANDLERS: dict[USBType, Type[USBHandler]] = {
         USBType.ROBOT: RobotUSBHandler,
         USBType.METADATA: MetadataUSBHandler,
-    }  # type: Dict[USBType, Type[USBHandler]]
+    }
 
     def __init__(self) -> None:
-        self.mountpoint_handlers = {}  # type: Dict[str, USBHandler]
-        self.mountpoint_types = {}  # type: Dict[str, USBType]
+        self.mountpoint_handlers: dict[str, USBHandler] = {}
+        self.mountpoint_types: dict[str, USBType] = {}
 
     def update_filesystems(self, mountpoints: Iterator[Mountpoint]) -> None:
         actual_mountpoint_paths = {

--- a/runusb
+++ b/runusb
@@ -222,27 +222,21 @@ class AutorunProcessRegistry(object):
         self.mountpoint_types: dict[str, USBType] = {}
 
     def update_filesystems(self, mountpoints: Iterator[Mountpoint]) -> None:
-        actual_mountpoint_paths = {
+        actual_mountpoints = {
             x.mountpoint
             for x in mountpoints
             if self._is_viable_mountpoint(x)
         }
 
-        expected_mountpoint_paths = set(self.mountpoint_handlers.keys())
+        expected_mountpoints = set(self.mountpoint_handlers.keys())
 
         # Handle newly detected filesystems
-        for new_mountpoint_path in (
-            actual_mountpoint_paths
-            - expected_mountpoint_paths
-        ):
-            self._detect_new_mountpoint_path(new_mountpoint_path)
+        for new_mountpoint in (actual_mountpoints - expected_mountpoints):
+            self._detect_new_mountpoint_path(new_mountpoint)
 
         # Handle now-dead filesystems
-        for old_mountpoint_path in (
-            expected_mountpoint_paths
-            - actual_mountpoint_paths
-        ):
-            self._detect_dead_mountpoint_path(old_mountpoint_path)
+        for old_mountpoint in (expected_mountpoints - actual_mountpoints):
+            self._detect_dead_mountpoint_path(old_mountpoint)
 
     def _detect_new_mountpoint_path(self, path: str) -> None:
         LOGGER.info("Found new mountpoint: %s", path)

--- a/runusb
+++ b/runusb
@@ -56,7 +56,7 @@ class LEDController():
         if IS_PI:
             LOGGER.debug("Configuring LED controller")
             atexit.register(GPIO.cleanup)  # type: ignore[attr-defined]
-            GPIO.setmode(GPIO.BOARD)
+            GPIO.setmode(GPIO.BCM)
             GPIO.setup([led.value for led in self.LEDs], GPIO.OUT, initial=GPIO.LOW)
 
     def red(self) -> None:

--- a/runusb
+++ b/runusb
@@ -33,15 +33,23 @@ class Mountpoint(NamedTuple):
 
 
 VERBOTEN_FILESYSTEMS = (
+    'autofs',
+    'bpf',
     'cgroup',
+    'cgroup2',
     'configfs',
     'debugfs',
     'devpts',
     'devtmpfs',
+    'fusectl',
     'hugetlbfs',
     'mqueue',
     'proc',
+    'pstore',
+    'rpc_pipefs',
+    'securityfs',
     'sysfs',
+    'tracefs',
 )
 
 

--- a/runusb
+++ b/runusb
@@ -219,7 +219,6 @@ class AutorunProcessRegistry(object):
 
     def __init__(self) -> None:
         self.mountpoint_handlers: dict[str, USBHandler] = {}
-        self.mountpoint_types: dict[str, USBType] = {}
 
     def update_filesystems(self, mountpoints: Iterator[Mountpoint]) -> None:
         actual_mountpoints = {
@@ -245,7 +244,6 @@ class AutorunProcessRegistry(object):
         handler = handler_class(path)
         LOGGER.info("  -> launched handler")
         self.mountpoint_handlers[path] = handler
-        self.mountpoint_types[path] = usb_type
 
     def _detect_dead_mountpoint_path(self, path: str) -> None:
         LOGGER.info("Lost mountpoint: %s", path)
@@ -253,7 +251,6 @@ class AutorunProcessRegistry(object):
         handler.close()
         LOGGER.info("  -> closed handler")
         del self.mountpoint_handlers[path]
-        del self.mountpoint_types[path]
 
     def _is_viable_mountpoint(self, mountpoint: Mountpoint) -> bool:
         # Drop restricted types

--- a/runusb
+++ b/runusb
@@ -247,8 +247,8 @@ class AutorunProcessRegistry(object):
             self._detect_dead_mountpoint_path(old_mountpoint)
 
     def _detect_new_mountpoint_path(self, path: str) -> None:
-        LOGGER.info(f"Found new mountpoint: {path}")
         usb_type = detect_usb_type(path)
+        LOGGER.info(f"Found new mountpoint: {path} ({usb_type})")
         handler_class = self.TYPE_HANDLERS[usb_type]
         handler = handler_class(path)
         LOGGER.info("  -> launched handler")

--- a/runusb
+++ b/runusb
@@ -180,10 +180,11 @@ class RobotUSBHandler(USBHandler):
     def close(self) -> None:
         self._send_signal(signal.SIGTERM)
         try:
+            # Wait for the process to exit
             self.process.communicate(timeout=5)
         except subprocess.TimeoutExpired:
-            pass
-        self._send_signal(signal.SIGKILL)
+            # The process did not exit after 5 seconds, so kill it.
+            self._send_signal(signal.SIGKILL)
         self._set_leds()
 
     def _send_signal(self, sig: int) -> None:

--- a/runusb
+++ b/runusb
@@ -22,7 +22,6 @@ LOGGER = logging.getLogger('runusb')
 
 PROC_FILE = '/proc/mounts'
 ROBOT_FILE = 'robot.py'
-SPAWN_IMAGE = '/mnt/rootmirror'
 MOUNTPOINT_DIR = '/media'  # the directory under which all USBs will be mounted
 METADATA_FILENAME = 'metadata.json'
 
@@ -89,8 +88,12 @@ class USBType(Enum):
 
 
 def detect_usb_type(mountpoint: str) -> USBType:
-    # subpaths of the root image are excluded
-    if mountpoint.startswith(SPAWN_IMAGE):
+    # only mountpoints under MOUNTPOINT_DIR are considered
+    if not mountpoint.startswith(MOUNTPOINT_DIR):
+        LOGGER.debug(
+            f"Disregarding filesystem {mountpoint} of type "
+            f"{mountpoint.filesystem} is not under {MOUNTPOINT_DIR}."
+        )
         return USBType.INVALID
 
     # Check for the existence of the robot code

--- a/stubs/RPi/GPIO.pyi
+++ b/stubs/RPi/GPIO.pyi
@@ -1,4 +1,5 @@
 BOARD = 10
+BCM = 11
 
 LOW = 0
 HIGH = 1


### PR DESCRIPTION
- Updating to 3.8 style typehints
- Removing dead code in FSTabReader & AutorunProcessRegistry
- Rework what is logged to be more useful when diagnosing non-running USBs
- Removing the servo hack
- Enforce that viable mountpoints are in the expected mountpoint directory
- Log the detected type of now mountpoints