### PR TITLE
Build deb on arm

### DIFF
--- a/.github/workflows/debuild.yml
+++ b/.github/workflows/debuild.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pguyot/arm-runner-action@v2
         with:
-          base_image: raspios_lite:2022-04-04
+          base_image: raspios_lite_arm64:2022-04-04
           commands: |
             sudo apt-get update
             sudo apt-get install --yes build-essential devscripts debhelper

--- a/.github/workflows/debuild.yml
+++ b/.github/workflows/debuild.yml
@@ -13,16 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes build-essential devscripts debhelper
-      - name: Build package
-        run: debuild -uc -us
+      - uses: pguyot/arm-runner-action@v2
+        with:
+          base_image: raspios_lite:2022-04-04
+          commands: |
+            sudo apt-get update
+            sudo apt-get install --yes build-essential devscripts debhelper
+            debuild -uc -us
+            cp ../*.deb .
       - name: Get debian package name
         run: |
-          echo "runusb_deb_path=$(realpath ../*.deb)" >> $GITHUB_ENV
-          echo "runusb_deb_name=$(basename ../*.deb)" >> $GITHUB_ENV
+          echo "runusb_deb_path=$(realpath *.deb)" >> $GITHUB_ENV
+          echo "runusb_deb_name=$(basename *.deb)" >> $GITHUB_ENV
       - name: Save deb artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/debuild.yml
+++ b/.github/workflows/debuild.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: pguyot/arm-runner-action@v2
         with:
           base_image: raspios_lite_arm64:2022-04-04
+          bind_mount_repository: true
           commands: |
             sudo apt-get update
             sudo apt-get install --yes build-essential devscripts debhelper


### PR DESCRIPTION
Attempt to fix issue discovered in https://github.com/sourcebots/robot-image/pull/7.

Instead of explicitly running CI on Debian, we also run on Arm, so the resulting `.deb` has the right architecture, and future native build components are configured correctly.