### PR TITLE
Add logging to MQTT

### DIFF
--- a/runusb/__main__.py
+++ b/runusb/__main__.py
@@ -427,6 +427,7 @@ def setup_usercode_logging() -> None:
                 use_tls=mqtt_config.use_tls,
                 username=mqtt_config.username,
                 password=mqtt_config.password,
+                connected_topic=f"{mqtt_config.topic_prefix}/connected",
             )
 
             handler.setLevel(logging.INFO)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,9 @@ install_requires =
     logger-extras==0.3.2
     rpi.GPIO==0.7.1
 
+[options.extras_require]
+mqtt = logger-extras[mqtt]==0.3.2
+
 [options.entry_points]
 console_scripts =
     runusb = runusb.__main__:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ install_requires =
     rpi.GPIO==0.7.1
 
 [options.extras_require]
-mqtt = logger-extras[mqtt]==0.3.2
+mqtt = logger-extras[mqtt]==0.3.3
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ url = https://github.com/sourcebots/runusb
 python_requires = >=3.8
 packages = find:
 install_requires =
-    logger-extras==0.2.0
+    logger-extras==0.3.2
     rpi.GPIO==0.7.1
 
 [options.entry_points]


### PR DESCRIPTION
Use logger-extra's MQTTHandler to send log messages over MQTT when configured in `/etc/sbot/mqtt.conf`

example config:

```json
{
    "host": "localhost",
    "port": 8883,
    "topic_prefix": "team0",
    "use_tls": true,
    "username": "team0",
    "password": "abc"
}
```

Log messages are in the format:

```jsonc
{
    "timestamp": 1690634642.9473646,  //The time the message was logged in seconds since the epoch
    "message": "[0001.093] sbot.robot - INFO - SourceBots API v1.0.0rc2.dev6+g21313b1.d20230729",  // The message after formatiing
    "raw_message": "sbot.robot - INFO - SourceBots API v1.0.0rc2.dev6+g21313b1.d20230729",  // The message as it was logged
    "level": "USERCODE",  // The string of the log level
    "name": "usercode"  // The name of the logger that logged this
}
```
