### PR TITLE
Add support for KCH leds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
       MYPY: venv/bin/mypy
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Set up virtualenv
       run: python -m venv venv
     - name: Install dependencies

--- a/runusb/__main__.py
+++ b/runusb/__main__.py
@@ -456,6 +456,8 @@ def setup_usercode_logging() -> None:
                 username=mqtt_config.username,
                 password=mqtt_config.password,
                 connected_topic=f"{mqtt_config.topic_prefix}/connected",
+                connected_callback=lambda: LED_CONTROLLER.set_wifi(True),
+                disconnected_callback=lambda: LED_CONTROLLER.set_wifi(False),
             )
 
             handler.setLevel(logging.INFO)

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,11 +11,11 @@ url = https://github.com/sourcebots/runusb
 python_requires = >=3.8
 packages = find:
 install_requires =
-    logger-extras==0.4.0
+    logger-extras==0.4.1
     rpi.GPIO==0.7.1
 
 [options.extras_require]
-mqtt = logger-extras[mqtt]==0.4.0
+mqtt = logger-extras[mqtt]==0.4.1
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
The OK led displays the current status of usercode:
- No USB: off
- Running: blue
- Killed: magenta
- Finished: green
- Crashed: red

Code is lit when the usercode USB is connected
Comp is lit when the comp-mode USB is connected
Wifi is lit when connected to MQTT
Boot 100% is lit just before the mounts file is first read

Now includes publishing the set  status on MQTT